### PR TITLE
Fix

### DIFF
--- a/vm/ps/Invoke-Meter.ps1
+++ b/vm/ps/Invoke-Meter.ps1
@@ -34,7 +34,8 @@ function Invoke-Meter() {
     # Get the token for calling the metering API
     $MeteringApiResourceID="20e940b3-4c77-4b0b-9a53-9e16a1b010a7"
     $MeteringApiTokenUrl = "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=$($MeteringApiResourceID)"
-    $AuthResponse = Invoke-RestMethod -Headers @{ "Metadata" = "true" } -Uri $MeteringApiTokenUrl 
+    $AuthResponse = Invoke-RestMethod -Headers @{ "Metadata" = "true" } -Uri $MeteringApiTokenUrl
+    $Headers = @{}
     $Headers.Add("Authorization", "$($AuthResponse.token_type) $($AuthResponse.access_token)")
 
     # Set to use TLS 1.2


### PR DESCRIPTION
## Purpose

- Must use a fresh dictionary for the actual metering call. In the old code, the `Headers` dictionary already has an access token, so trying to add the second one fails the script.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->